### PR TITLE
Add logic to correctly display time if minute is less than 10.

### DIFF
--- a/app/src/main/java/ohi/andre/consolelauncher/commands/main/raw/time.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/commands/main/raw/time.java
@@ -16,8 +16,11 @@ public class time implements CommandAbstraction {
         Calendar c = Calendar.getInstance();
         int hours = c.get(Calendar.HOUR_OF_DAY);
         int minutes = c.get(Calendar.MINUTE);
-
-        return hours + ":" + minutes;
+		
+		if(minutes < 10)
+			return hours + ":0" + minutes;
+		else
+			return hours + ":" + minutes;
     }
 
     @Override


### PR DESCRIPTION
Fixes time display issue where minute is less than 10.  Example: 12:03 incorrectly displays as 12:3.