### PR TITLE
Adding font customization (revised)

### DIFF
--- a/app/src/main/java/ohi/andre/consolelauncher/UIManager.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/UIManager.java
@@ -527,8 +527,6 @@ public class UIManager implements OnTouchListener {
 
         trigger = tri;
 
-        final Typeface lucidaConsole = Typeface.createFromAsset(context.getAssets(), "lucida_console.ttf");
-
         imm = (InputMethodManager) mContext.getSystemService(Context.INPUT_METHOD_SERVICE);
         skinManager = new SkinManager();
 
@@ -589,7 +587,7 @@ public class UIManager implements OnTouchListener {
         final int BATTERY = 4;
         final int STORAGE = 5;
 
-        Typeface t = skinManager.systemFont ? Typeface.DEFAULT : lucidaConsole;
+        final Typeface t = skinManager.getFont(Typeface.createFromAsset(context.getAssets(), "lucida_console.ttf"));
 
         AllowEqualsSequence sequence = new AllowEqualsSequence(new int[] {rIndex, dIndex, bIndex, tIndex, sIndex}, new Integer[] {RAM, DEVICE, BATTERY, TIME, STORAGE});
         for(int count = 0; count < ts.length; count++) {
@@ -735,7 +733,7 @@ public class UIManager implements OnTouchListener {
                     textView.setLongClickable(false);
                     textView.setClickable(true);
 
-                    textView.setTypeface(skinManager.systemFont ? Typeface.DEFAULT : lucidaConsole);
+                    textView.setTypeface(t);
                     textView.setTextSize(skinManager.getSuggestionSize());
 
                     textView.setPadding(SkinManager.SUGGESTION_PADDING_HORIZONTAL, SkinManager.SUGGESTION_PADDING_VERTICAL,

--- a/app/src/main/java/ohi/andre/consolelauncher/commands/tuixt/TuixtActivity.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/commands/tuixt/TuixtActivity.java
@@ -61,7 +61,6 @@ public class TuixtActivity extends Activity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        final Typeface lucidaConsole = Typeface.createFromAsset(getAssets(), "lucida_console.ttf");
         final LinearLayout rootView = new LinearLayout(this);
 
         final Intent intent = getIntent();
@@ -86,6 +85,8 @@ public class TuixtActivity extends Activity {
                 return;
             }
         }
+
+        final Typeface useFont = skinManager.getFont(Typeface.createFromAsset(getAssets(), "lucida_console.ttf"));
 
         if (!skinManager.useSystemWp) {
             rootView.setBackgroundColor(skinManager.bgColor);
@@ -115,7 +116,7 @@ public class TuixtActivity extends Activity {
 
         String prefix = skinManager.prefix;
 
-        prefixView.setTypeface(skinManager.systemFont ? Typeface.DEFAULT : lucidaConsole);
+        prefixView.setTypeface(useFont);
         prefixView.setTextColor(skinManager.inputColor);
         prefixView.setTextSize(skinManager.getTextSize());
         prefixView.setText(prefix.endsWith(Tuils.SPACE) ? prefix : prefix + Tuils.SPACE);
@@ -130,7 +131,7 @@ public class TuixtActivity extends Activity {
             });
         }
 
-        fileView.setTypeface(skinManager.systemFont ? Typeface.DEFAULT : lucidaConsole);
+        fileView.setTypeface(useFont);
         fileView.setTextSize(skinManager.getTextSize());
         fileView.setTextColor(skinManager.outputColor);
         fileView.setOnTouchListener(new View.OnTouchListener() {
@@ -145,13 +146,13 @@ public class TuixtActivity extends Activity {
             }
         });
 
-        outputView.setTypeface(skinManager.systemFont ? Typeface.DEFAULT : lucidaConsole);
+        outputView.setTypeface(useFont);
         outputView.setTextSize(skinManager.getTextSize());
         outputView.setTextColor(skinManager.outputColor);
         outputView.setMovementMethod(new ScrollingMovementMethod());
         outputView.setVisibility(View.GONE);
 
-        inputView.setTypeface(skinManager.systemFont ? Typeface.DEFAULT : lucidaConsole);
+        inputView.setTypeface(useFont);
         inputView.setTextSize(skinManager.getTextSize());
         inputView.setTextColor(skinManager.inputColor);
         inputView.setHint(Tuils.getHint(skinManager, path));

--- a/app/src/main/java/ohi/andre/consolelauncher/managers/SkinManager.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/managers/SkinManager.java
@@ -1,10 +1,13 @@
 package ohi.andre.consolelauncher.managers;
 
 import android.graphics.Color;
+import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
+
+import java.io.File;
 
 import ohi.andre.consolelauncher.managers.suggestions.SuggestionsManager;
 
@@ -23,6 +26,7 @@ public class SkinManager implements Parcelable {
     public int globalFontSize;
 
     public String deviceName;
+    public String userFontPath;
     public int deviceColor, inputColor, outputColor, ramColor, bgColor, overlayColor, toolbarColor, toolbarBg, enter_color, time_color, battery_color_high, battery_color_medium, battery_color_low,
             storageColor;
 
@@ -35,6 +39,7 @@ public class SkinManager implements Parcelable {
 
     public SkinManager() {
         systemFont = XMLPrefsManager.get(boolean.class, XMLPrefsManager.Ui.system_font);
+        userFontPath = XMLPrefsManager.get(String.class, XMLPrefsManager.Ui.user_font_file);
         inputBottom = XMLPrefsManager.get(boolean.class, XMLPrefsManager.Ui.input_bottom);
         showSubmit = XMLPrefsManager.get(boolean.class, XMLPrefsManager.Ui.show_enter_button);
 
@@ -105,6 +110,7 @@ public class SkinManager implements Parcelable {
 
     protected SkinManager(Parcel in) {
         globalFontSize = in.readInt();
+        userFontPath = in.readString();
         deviceName = in.readString();
         deviceColor = in.readInt();
         inputColor = in.readInt();
@@ -156,6 +162,25 @@ public class SkinManager implements Parcelable {
             return new SkinManager[size];
         }
     };
+
+    public Typeface getFont(Typeface defaultTypeface)
+    {
+        if (systemFont)
+        {
+            return Typeface.DEFAULT;
+        }
+        else {
+            try {
+                File userFontFile = new File(userFontPath);
+                if (userFontFile.exists() && userFontFile.isFile()) {
+                    return Typeface.createFromFile(userFontPath);
+                } else
+                    throw new Exception("The specified font file is invalid. Using built-in font.");
+            } catch (Exception ex) {
+                return defaultTypeface;
+            }
+        }
+    }
 
     public ColorDrawable getSuggestionBg(Integer type) {
         if(transparentSuggestions) {
@@ -227,6 +252,7 @@ public class SkinManager implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeInt(globalFontSize);
+        dest.writeString(userFontPath);
         dest.writeString(deviceName);
         dest.writeInt(deviceColor);
         dest.writeInt(inputColor);

--- a/app/src/main/java/ohi/andre/consolelauncher/managers/TerminalManager.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/managers/TerminalManager.java
@@ -112,7 +112,7 @@ public class TerminalManager {
 
         this.mContext = context;
 
-        final Typeface lucidaConsole = Typeface.createFromAsset(context.getAssets(), "lucida_console.ttf");
+        final Typeface useFont = skinManager.getFont(Typeface.createFromAsset(context.getAssets(), "lucida_console.ttf"));
 
         this.mSkinManager = skinManager;
         this.mainPack = mainPack;
@@ -127,7 +127,7 @@ public class TerminalManager {
         prefix = skinManager.prefix;
         suPrefix = XMLPrefsManager.get(String.class, XMLPrefsManager.Ui.input_root_prefix);
 
-        prefixView.setTypeface(skinManager.systemFont ? Typeface.DEFAULT : lucidaConsole);
+        prefixView.setTypeface(useFont);
         prefixView.setTextColor(this.mSkinManager.inputColor);
         prefixView.setTextSize(this.mSkinManager.getTextSize());
         prefixView.setText(prefix.endsWith(Tuils.SPACE) ? prefix : prefix + Tuils.SPACE);
@@ -188,7 +188,7 @@ public class TerminalManager {
         }
 
         this.mTerminalView = terminalView;
-        this.mTerminalView.setTypeface(skinManager.systemFont ? Typeface.DEFAULT : lucidaConsole);
+        this.mTerminalView.setTypeface(useFont);
         this.mTerminalView.setTextSize(mSkinManager.getTextSize());
         this.mTerminalView.setFocusable(false);
         setupScroller();
@@ -233,7 +233,7 @@ public class TerminalManager {
         this.mInputView = inputView;
         this.mInputView.setTextSize(mSkinManager.getTextSize());
         this.mInputView.setTextColor(mSkinManager.inputColor);
-        this.mInputView.setTypeface(skinManager.systemFont ? Typeface.DEFAULT : lucidaConsole);
+        this.mInputView.setTypeface(useFont);
         this.mInputView.setHint(Tuils.getHint(skinManager, mainPack.currentDirectory.getAbsolutePath()));
         this.mInputView.setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
         this.mInputView.setOnEditorActionListener(new TextView.OnEditorActionListener() {

--- a/app/src/main/java/ohi/andre/consolelauncher/managers/XMLPrefsManager.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/managers/XMLPrefsManager.java
@@ -203,6 +203,10 @@ public class XMLPrefsManager {
                 return "false";
             }
         },
+        user_font_file {
+            @Override
+            public String defaultValue() { return "/sdcard/t-ui/userfont.ttf"; }
+        },
         font_size {
             @Override
             public String defaultValue() {


### PR DESCRIPTION
I reworked the font customization feature based on the latest commit.

Usage: Place your own font file in the location as defined in the user_font_path parameter in UI.xml, and the font will be loaded for text display. If the file fails to load for whatever reason, the built-in font will be used instead.

Additionally, for convenience I merged the system_font check into the getFont method as well, so on top of loading the user-defined font, it'll return the default system Typeface (Typeface.DEFAULT) when system_font parameter is set true.