### PR TITLE
fix: improve 'uninstall' command reliability and manifest permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
 
     <!-- features -->
     <uses-feature

--- a/app/src/main/java/ohi/andre/consolelauncher/commands/main/raw/tui.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/commands/main/raw/tui.java
@@ -40,8 +40,9 @@ public class tui extends ParamCommand {
                 ComponentName name = new ComponentName(info.context, PolicyReceiver.class);
                 policy.removeActiveAdmin(name);
 
-                Uri packageURI = Uri.parse("package:" + BuildConfig.APPLICATION_ID);
+                Uri packageURI = Uri.fromParts("package", BuildConfig.APPLICATION_ID, null);
                 Intent uninstallIntent = new Intent(Intent.ACTION_DELETE, packageURI);
+                uninstallIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 info.context.startActivity(uninstallIntent);
 
                 return null;

--- a/app/src/main/java/ohi/andre/consolelauncher/commands/main/raw/uninstall.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/commands/main/raw/uninstall.java
@@ -38,7 +38,7 @@ public class uninstall implements CommandAbstraction {
             return e.toString();
         }
 
-        return "Uninstallation started for: " + packageName;
+        return String.format("Uninstalling %s...", packageName);
     }
 
     @Override

--- a/app/src/main/java/ohi/andre/consolelauncher/commands/main/raw/uninstall.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/commands/main/raw/uninstall.java
@@ -7,6 +7,7 @@ import ohi.andre.consolelauncher.R;
 import ohi.andre.consolelauncher.commands.CommandAbstraction;
 import ohi.andre.consolelauncher.commands.ExecutePack;
 import ohi.andre.consolelauncher.commands.main.MainPack;
+import ohi.andre.consolelauncher.managers.AppsManager;
 import ohi.andre.consolelauncher.tuils.Tuils;
 
 public class uninstall implements CommandAbstraction {
@@ -15,13 +16,29 @@ public class uninstall implements CommandAbstraction {
     public String exec(ExecutePack pack) {
         MainPack info = (MainPack) pack;
 
-        String packageName = info.getLaunchInfo().componentName.getPackageName();
+        AppsManager.LaunchInfo launchInfo = info.getLaunchInfo();
+        if (launchInfo == null || launchInfo.componentName == null) {
+            return info.res.getString(R.string.output_appnotfound);
+        }
 
-        Uri packageURI = Uri.parse("package:" + packageName);
-        Intent uninstallIntent = new Intent(Intent.ACTION_DELETE, packageURI);
-        info.context.startActivity(uninstallIntent);
+        return uninstall(info, launchInfo.componentName.getPackageName());
+    }
 
-        return Tuils.EMPTYSTRING;
+    private String uninstall(MainPack info, String packageName) {
+        if (packageName == null || packageName.isEmpty()) {
+            return info.res.getString(R.string.output_appnotfound);
+        }
+
+        try {
+            Uri packageURI = Uri.fromParts("package", packageName, null);
+            Intent uninstallIntent = new Intent(Intent.ACTION_DELETE, packageURI);
+            uninstallIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            info.context.startActivity(uninstallIntent);
+        } catch (Exception e) {
+            return e.toString();
+        }
+
+        return "Uninstallation started for: " + packageName;
     }
 
     @Override
@@ -31,7 +48,7 @@ public class uninstall implements CommandAbstraction {
 
     @Override
     public int[] argType() {
-        return new int[]{CommandAbstraction.VISIBLE_PACKAGE};
+        return new int[]{CommandAbstraction.ALL_PACKAGES};
     }
 
     @Override
@@ -48,7 +65,20 @@ public class uninstall implements CommandAbstraction {
     @Override
     public String onArgNotFound(ExecutePack pack, int index) {
         MainPack info = (MainPack) pack;
-        return info.res.getString(R.string.output_appnotfound);
+        String arg = (String) pack.args[index];
+
+        // Attempt to find the app in ALL_PACKAGES (including hidden) even if argType parsing failed
+        AppsManager.LaunchInfo li = info.appsManager.findLaunchInfoWithLabel(arg, AppsManager.HIDDEN_APPS);
+        if (li == null) {
+            li = info.appsManager.findLaunchInfoWithLabel(arg, AppsManager.SHOWN_APPS);
+        }
+
+        if (li != null && li.componentName != null) {
+            return uninstall(info, li.componentName.getPackageName());
+        }
+
+        // If still not found, assume the arg might be the package name itself
+        return uninstall(info, arg);
     }
 
 }


### PR DESCRIPTION
This PR fixes the 'uninstall' command which was failing on modern Android versions.

### **Key Changes**
*   **Manifest**: Added the mandatory `REQUEST_DELETE_PACKAGES` permission for initiating uninstallation intents.
*   **Reliability**: Updated the uninstallation intent to use `Uri.fromParts` and added `FLAG_ACTIVITY_NEW_TASK` to ensure the system dialog triggers reliably from the launcher context.
*   **UX**: Added a fallback search in `onArgNotFound`. If the initial app resolution fails, the command now manually checks both shown and hidden app lists for a matching label, allowing uninstallation of hidden apps.
*   **Feedback**: Updated the output message to clearly state that uninstallation has started for the target package.